### PR TITLE
Silverstripe 6 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         }
     ],
     "require": {
-        "silverstripe/vendor-plugin": "^1.0 | ^2.0",
-        "silverstripe/cms": "^4.0 | ^5.0",
+        "silverstripe/cms": "^6",
         "ext-sodium": "*",
         "guzzlehttp/guzzle": "^7",
         "guzzlehttp/promises": "^2"

--- a/src/Core/ClientCommon.php
+++ b/src/Core/ClientCommon.php
@@ -2,18 +2,20 @@
 
 namespace BiffBangPow\SSMonitor\Client\Core;
 
+use Exception;
+
 trait ClientCommon
 {
 
     /**
      * Get the client name/identifier for this client module
      * @return string
-     * @throws \Exception
+     * @throws Exception
      */
     public function getClientName(): string
     {
         if ($this->clientName === '') {
-            throw new \Exception("No client name defined for monitoring client");
+            throw new Exception("No client name defined for monitoring client");
         }
         return $this->clientName;
     }
@@ -21,7 +23,7 @@ trait ClientCommon
     /**
      * Get the friendly name for this client module
      * @return string
-     * @throws \Exception
+     * @throws Exception
      */
     public function getClientTitle(): string
     {

--- a/src/Extension/ConfigExtension.php
+++ b/src/Extension/ConfigExtension.php
@@ -17,7 +17,7 @@ use SilverStripe\View\HTML;
  */
 class ConfigExtension extends Extension
 {
-    public function updateCMSFields(FieldList $fields)
+    protected function updateCMSFields(FieldList $fields)
     {
         $status = $this->getStatus();
         $statusHTML = HTML::createTag('div', [], $status);

--- a/src/Extension/ConfigExtension.php
+++ b/src/Extension/ConfigExtension.php
@@ -2,11 +2,8 @@
 
 namespace BiffBangPow\SSMonitor\Client\Extension;
 
+use SilverStripe\SiteConfig\SiteConfig;
 use BiffBangPow\SSMonitor\Client\Core\ClientInterface;
-use BiffBangPow\SSMonitor\Client\Module\AllPackageVersions;
-use BiffBangPow\SSMonitor\Client\Module\CorePackageVersions;
-use BiffBangPow\SSMonitor\Client\Module\SSConfiguration;
-use BiffBangPow\SSMonitor\Client\Module\SystemInfo;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\FieldList;
@@ -16,7 +13,7 @@ use SilverStripe\View\HTML;
 /**
  * Class \BiffBangPow\SSMonitor\Client\Extension\ConfigExtension
  *
- * @property \SilverStripe\SiteConfig\SiteConfig|\BiffBangPow\SSMonitor\Client\Extension\ConfigExtension $owner
+ * @property SiteConfig|\BiffBangPow\SSMonitor\Client\Extension\ConfigExtension $owner
  */
 class ConfigExtension extends Extension
 {

--- a/src/Helper/EncryptionHelper.php
+++ b/src/Helper/EncryptionHelper.php
@@ -2,6 +2,7 @@
 
 namespace BiffBangPow\SSMonitor\Client\Helper;
 
+use Exception;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Environment;
 
@@ -33,7 +34,7 @@ class EncryptionHelper
         $encSalt = Environment::getEnv('MONITORING_ENC_SALT');
 
         if (!$encSalt || !$encSecret) {
-            throw new \Exception("Missing encryption keys in environment");
+            throw new Exception("Missing encryption keys in environment");
         }
 
         $this->setSecret($encSecret);

--- a/src/Module/AllPackageVersions.php
+++ b/src/Module/AllPackageVersions.php
@@ -2,13 +2,15 @@
 
 namespace BiffBangPow\SSMonitor\Client\Module;
 
+use ReflectionClass;
+use SilverStripe\Model\List\ArrayList;
+use SilverStripe\Model\ArrayData;
+use SilverStripe\ORM\FieldType\DBHTMLText;
+use Exception;
 use BiffBangPow\SSMonitor\Client\Core\ClientCommon;
 use BiffBangPow\SSMonitor\Client\Core\ClientInterface;
 use SilverStripe\Core\Config\Configurable;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\VersionProvider;
-use SilverStripe\ORM\ArrayList;
-use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
 class AllPackageVersions implements ClientInterface
@@ -35,7 +37,7 @@ class AllPackageVersions implements ClientInterface
         /**
          * @var VersionProvider $versionProvider
          */
-        $ref = new \ReflectionClass(VersionProvider::class);
+        $ref = new ReflectionClass(VersionProvider::class);
         $refMethod = $ref->getMethod('getComposerLock');
         $refMethod->setAccessible(true);
 
@@ -56,8 +58,8 @@ class AllPackageVersions implements ClientInterface
 
     /**
      *
-     * @return \SilverStripe\ORM\FieldType\DBHTMLText
-     * @throws \Exception
+     * @return DBHTMLText
+     * @throws Exception
      */
     public function forTemplate()
     {

--- a/src/Module/AllPackageVersions.php
+++ b/src/Module/AllPackageVersions.php
@@ -2,7 +2,7 @@
 
 namespace BiffBangPow\SSMonitor\Client\Module;
 
-use ReflectionClass;
+use Composer\InstalledVersions;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Model\ArrayData;
 use SilverStripe\ORM\FieldType\DBHTMLText;
@@ -10,7 +10,6 @@ use Exception;
 use BiffBangPow\SSMonitor\Client\Core\ClientCommon;
 use BiffBangPow\SSMonitor\Client\Core\ClientInterface;
 use SilverStripe\Core\Config\Configurable;
-use SilverStripe\Core\Manifest\VersionProvider;
 use SilverStripe\View\SSViewer;
 
 class AllPackageVersions implements ClientInterface
@@ -34,21 +33,17 @@ class AllPackageVersions implements ClientInterface
     {
         $packages = [];
 
-        /**
-         * @var VersionProvider $versionProvider
-         */
-        $ref = new ReflectionClass(VersionProvider::class);
-        $refMethod = $ref->getMethod('getComposerLock');
-        $refMethod->setAccessible(true);
+        // Get all installed packages using Composer's InstalledVersions API
+        $installedPackages = InstalledVersions::getInstalledPackages();
 
-        $lockContents = $refMethod->invoke(new VersionProvider());
-
-        if (isset($lockContents['packages'])) {
-            foreach ($lockContents['packages'] as $package) {
-                $packageName = $package['name'];
-                $version = $package['version'];
-                $packages[$packageName] = $version;
+        foreach ($installedPackages as $packageName) {
+            // Skip the root package
+            if (InstalledVersions::getRootPackage()['name'] === $packageName) {
+                continue;
             }
+
+            $version = InstalledVersions::getPrettyVersion($packageName);
+            $packages[$packageName] = $version;
         }
 
         return [

--- a/src/Module/CorePackageVersions.php
+++ b/src/Module/CorePackageVersions.php
@@ -2,14 +2,15 @@
 
 namespace BiffBangPow\SSMonitor\Client\Module;
 
+use SilverStripe\Model\List\ArrayList;
+use SilverStripe\Model\ArrayData;
+use SilverStripe\ORM\FieldType\DBHTMLText;
+use Exception;
 use BiffBangPow\SSMonitor\Client\Core\ClientCommon;
 use BiffBangPow\SSMonitor\Client\Core\ClientInterface;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\VersionProvider;
-use SilverStripe\ORM\ArrayList;
-use SilverStripe\View\ArrayData;
-use SilverStripe\View\HTML;
 use SilverStripe\View\SSViewer;
 
 class CorePackageVersions implements ClientInterface
@@ -41,8 +42,8 @@ class CorePackageVersions implements ClientInterface
 
     /**
      *
-     * @return \SilverStripe\ORM\FieldType\DBHTMLText
-     * @throws \Exception
+     * @return DBHTMLText
+     * @throws Exception
      */
     public function forTemplate()
     {

--- a/src/Module/SSConfiguration.php
+++ b/src/Module/SSConfiguration.php
@@ -2,14 +2,14 @@
 
 namespace BiffBangPow\SSMonitor\Client\Module;
 
+use SilverStripe\Model\List\ArrayList;
+use SilverStripe\Model\ArrayData;
 use BiffBangPow\SSMonitor\Client\Core\ClientCommon;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Configurable;
 use BiffBangPow\SSMonitor\Client\Core\ClientInterface;
 use SilverStripe\Core\Environment;
-use SilverStripe\ORM\ArrayList;
 use SilverStripe\SiteConfig\SiteConfig;
-use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
 class SSConfiguration implements ClientInterface
@@ -67,7 +67,7 @@ class SSConfiguration implements ClientInterface
             $data['defaultadmin']['value'] = ($data['defaultadmin']['value']) ? _t(__CLASS__ . '.yes', "Yes") : _t(__CLASS__ . '.no', "No");
         }
 
-        foreach ($data as $id => $values) {
+        foreach ($data as $values) {
             $variables->push(ArrayData::create([
                 'Variable' => $values['label'],
                 'Value' => $values['value']

--- a/src/Module/SystemInfo.php
+++ b/src/Module/SystemInfo.php
@@ -2,17 +2,19 @@
 
 namespace BiffBangPow\SSMonitor\Client\Module;
 
+use BiffBangPow\SSMonitor\Client\Core\ClientInterface;
+use SilverStripe\Model\List\ArrayList;
+use SilverStripe\Model\ArrayData;
+use Exception;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use BiffBangPow\SSMonitor\Client\Core\ClientCommon;
 use GuzzleHttp\Client;
-use GuzzleHttp\Promise;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Environment;
-use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DB;
-use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
-class SystemInfo implements \BiffBangPow\SSMonitor\Client\Core\ClientInterface
+class SystemInfo implements ClientInterface
 {
     use ClientCommon;
     use Configurable;
@@ -113,8 +115,8 @@ class SystemInfo implements \BiffBangPow\SSMonitor\Client\Core\ClientInterface
 
     /**
      *
-     * @return \SilverStripe\ORM\FieldType\DBHTMLText
-     * @throws \Exception
+     * @return DBHTMLText
+     * @throws Exception
      */
     public function forTemplate()
     {
@@ -134,7 +136,7 @@ class SystemInfo implements \BiffBangPow\SSMonitor\Client\Core\ClientInterface
             }
         }
 
-        foreach ($data as $id => $values) {
+        foreach ($data as $values) {
             $variables->push(ArrayData::create([
                 'Variable' => $values['label'],
                 'Value' => $values['value']
@@ -157,7 +159,7 @@ class SystemInfo implements \BiffBangPow\SSMonitor\Client\Core\ClientInterface
         try {
             $response = $promise->wait();
             $ipAddress = $response->getBody()->getContents();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             // Handle exception if request fails
             $ipAddress = _t(__CLASS__ . '.publiciperror', 'Error getting IP address');
         }


### PR DESCRIPTION
Silverstripe 6 compatibility, including utilisation of the `composer-runtime-api` instead of the now deprecated `getComposerLock`.